### PR TITLE
AsyncMap (Support for C# 8  Async Stream)

### DIFF
--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>IntegrationTests</AssemblyName>
     <RootNamespace>IntegrationTests</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -12,10 +12,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Neo4jMapper\Neo4jMapper.csproj" />
+    <ProjectReference Include="..\Neo4jMapperCore\Neo4jMapperCore.csproj" />
     <ProjectReference Include="..\Queries\Queries.csproj" />
   </ItemGroup>
 

--- a/src/IntegrationTests/TestFixtureBase.cs
+++ b/src/IntegrationTests/TestFixtureBase.cs
@@ -1,16 +1,30 @@
 ﻿using Neo4j.Driver.V1;
 using NUnit.Framework;
+using System;
 
 namespace IntegrationTests
 {
     public abstract class TestFixtureBase
     {
         protected IDriver Driver { get; private set; }
+        public static readonly string Url =
+                Environment.GetEnvironmentVariable("N4J_URL") ?? "bolt://localhost:7687";
+        public static readonly string User =
+                Environment.GetEnvironmentVariable("N4J_USER") ?? string.Empty;
+        public static readonly string Password =
+                Environment.GetEnvironmentVariable("N4J_PASS") ?? string.Empty;
+
+        public static IDriver CreateDriver()
+        {
+            if (string.IsNullOrEmpty(User))
+                return GraphDatabase.Driver(Url);
+            return GraphDatabase.Driver(Url, AuthTokens.Basic(User, Password));
+        }
 
         [OneTimeSetUp]
         protected virtual void TestFixtureSetUp()
         {
-            Driver = GraphDatabase.Driver("bolt://localhost:7687");
+            Driver = CreateDriver();
 
             // Ensure node exists to avoid flaky test where node id = 0
             using (var session = Driver.Session())
@@ -24,7 +38,7 @@ namespace IntegrationTests
         {
             using (var session = Driver.Session())
             {
-                session.RunAsync("MATCH (n:Neo4jMapperTest) DELETE n");
+                session.RunAsync("MATCH (n:Neo4jMapperTest) DETACH DELETE n");
             }
             Driver.Dispose();
         }

--- a/src/Neo4jMapper.sln
+++ b/src/Neo4jMapper.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Queries", "Queries\Queries.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{DB6FFD41-A536-42FC-95EB-F5026FAD1382}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neo4jMapper.Signed", "Neo4jMapper.Signed\Neo4jMapper.Signed.csproj", "{AB821832-D8EA-4D50-BC78-4AF0F3D28E25}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neo4jMapper.Signed", "Neo4jMapper.Signed\Neo4jMapper.Signed.csproj", "{AB821832-D8EA-4D50-BC78-4AF0F3D28E25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neo4jMapperCore", "Neo4jMapperCore\Neo4jMapperCore.csproj", "{03B455EC-DD3E-4DC6-9027-09975C7760C6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +45,10 @@ Global
 		{AB821832-D8EA-4D50-BC78-4AF0F3D28E25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AB821832-D8EA-4D50-BC78-4AF0F3D28E25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AB821832-D8EA-4D50-BC78-4AF0F3D28E25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B455EC-DD3E-4DC6-9027-09975C7760C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B455EC-DD3E-4DC6-9027-09975C7760C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B455EC-DD3E-4DC6-9027-09975C7760C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B455EC-DD3E-4DC6-9027-09975C7760C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Neo4jMapperCore/Neo4jMapperCore.csproj
+++ b/src/Neo4jMapperCore/Neo4jMapperCore.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>Neo4jMapper</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.6</Version>
+    <Title>Neo4jMapper</Title>
+    <Authors>Neil Dobson</Authors>
+    <Company>Barnardos Australia</Company>
+    <Description>A library to simplify mapping of cypher results onto your models</Description>
+    <PackageProjectUrl>https://github.com/barnardos-au/Neo4jMapper</PackageProjectUrl>
+    <PackageTags>neo4j cypher mapping</PackageTags>
+    <Copyright>Copyright ©2019 Barnardos Australia</Copyright>
+    <PackageIconUrl>https://avatars3.githubusercontent.com/u/29527012</PackageIconUrl>
+    <RepositoryUrl>https://github.com/barnardos-au/Neo4jMapper</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Neo4jMapper\CollectionMapper.cs" Link="CollectionMapper.cs" />
+    <Compile Include="..\Neo4jMapper\DictionaryExtensions.cs" Link="DictionaryExtensions.cs" />
+    <Compile Include="..\Neo4jMapper\EntityAccessor.cs" Link="EntityAccessor.cs" />
+    <Compile Include="..\Neo4jMapper\EntityExtensions.cs" Link="EntityExtensions.cs" />
+    <Compile Include="..\Neo4jMapper\Neo4jMapperConfig.cs" Link="Neo4jMapperConfig.cs" />
+    <Compile Include="..\Neo4jMapper\Neo4jParameters.cs" Link="Neo4jParameters.cs" />
+    <Compile Include="..\Neo4jMapper\NodeIdAttribute.cs" Link="NodeIdAttribute.cs" />
+    <Compile Include="..\Neo4jMapper\RecordExtensions.cs" Link="RecordExtensions.cs" />
+    <Compile Include="..\Neo4jMapper\SessionExtensions.cs" Link="SessionExtensions.cs" />
+    <Compile Include="..\Neo4jMapper\StatementResultCursorExtensions.cs" Link="StatementResultCursorExtensions.cs" />
+    <Compile Include="..\Neo4jMapper\ValueMapper.cs" Link="ValueMapper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Neo4j.Driver" Version="1.7.2" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="5.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Neo4jMapperCore/StatementResultCursorCoreExtensions.cs
+++ b/src/Neo4jMapperCore/StatementResultCursorCoreExtensions.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Neo4j.Driver.V1;
+
+namespace Neo4jMapper
+{
+    public static class StatementResultCursorCoreExtensions
+    {
+        #region Overloads
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TReturn>(
+   this IStatementResultCursor result)
+        {
+            return result.AsyncMap(
+                record => record.Map<TReturn>());
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TValue15, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TValue15, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        }
+
+        public static IAsyncEnumerable<TReturn> AsyncMap<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TValue15, TValue16, TReturn>(
+            this IStatementResultCursor result,
+            Func<TValue1, TValue2, TValue3, TValue4, TValue5, TValue6, TValue7, TValue8, TValue9, TValue10, TValue11, TValue12, TValue13, TValue14, TValue15, TValue16, TReturn> mapFunc)
+        {
+            return result.AsyncMap(
+                record => record.Map(mapFunc));
+        } 
+
+        #endregion // Overloads
+
+        public static async IAsyncEnumerable<TReturn> AsyncMap<TReturn>(
+            this IStatementResultCursor result,
+            Func<IRecord, TReturn> mapFunc)
+        {
+            var list = new List<TReturn>();
+            while (await result.FetchAsync().ConfigureAwait(false))
+            {
+                TReturn item = mapFunc(result.Current);
+                yield return item;
+            }
+        }
+    }
+}

--- a/src/Queries/Bolt.cs
+++ b/src/Queries/Bolt.cs
@@ -6,11 +6,24 @@ namespace Queries
 {
     public static class Bolt
     {
-        public const string Url = "bolt://localhost:7687";
+        public static readonly string Url =
+                Environment.GetEnvironmentVariable("N4J_URL") ?? "bolt://localhost:7687";
+        public static readonly string User = 
+            Environment.GetEnvironmentVariable("N4J_USER") ?? string.Empty;
+        public static readonly string Password = 
+            Environment.GetEnvironmentVariable("N4J_PASS") ?? string.Empty;
+
+        public static IDriver CreateDriver()
+        {
+            if (string.IsNullOrEmpty(User))
+                return GraphDatabase.Driver(Url);
+            return GraphDatabase.Driver(Url, AuthTokens.Basic(User, Password));
+        }
 
         public static async Task NewSession(Func<ISession, Task> statement)
         {
-            using (var driver = GraphDatabase.Driver(Url))
+
+            using (var driver = CreateDriver())
             {
                 using (var session = driver.Session())
                 {
@@ -21,7 +34,7 @@ namespace Queries
 
         public static async Task<T> NewSession<T>(Func<ISession, Task<T>> statement)
         {
-            using (var driver = GraphDatabase.Driver(Url))
+            using (var driver = CreateDriver())
             {
                 using (var session = driver.Session())
                 {

--- a/src/UnitTests/StatementResultCursorExtensionsAsyncMapTests.cs
+++ b/src/UnitTests/StatementResultCursorExtensionsAsyncMapTests.cs
@@ -1,0 +1,706 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Neo4j.Driver.V1;
+using Neo4jMapper;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class StatementResultCursorExtensionsAsyncMapTests
+    {
+        [Test]
+        public async Task AsyncMap_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap<int>().ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First());
+        }
+
+        [Test]
+        public async Task AsyncMap_2_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2) => new[]
+            {
+                value1,
+                value2
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+        }
+
+        [Test]
+        public async Task AsyncMap_3_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3) => new[]
+            {
+                value1,
+                value2,
+                value3
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+        }
+
+        [Test]
+        public async Task AsyncMap_4_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+        }
+
+        [Test]
+        public async Task AsyncMap_5_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+        }
+
+        [Test]
+        public async Task AsyncMap_6_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                    int value6) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+        }
+
+        [Test]
+        public async Task AsyncMap_7_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+        }
+
+        [Test]
+        public async Task AsyncMap_8_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+        }
+
+        [Test]
+        public async Task AsyncMap_9_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+        }
+
+        [Test]
+        public async Task AsyncMap_10_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+        }
+
+        [Test]
+        public async Task AsyncMap_11_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+        }
+
+        [Test]
+        public async Task AsyncMap_12_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+            record[11].Returns(12);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11,
+                int value12) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11,
+                value12
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+            Assert.AreEqual(12, result.First()[11]);
+        }
+
+        [Test]
+        public async Task AsyncMap_13_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+            record[11].Returns(12);
+            record[12].Returns(13);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11,
+                int value12, int value13) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11,
+                value12,
+                value13
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+            Assert.AreEqual(12, result.First()[11]);
+            Assert.AreEqual(13, result.First()[12]);
+        }
+
+        [Test]
+        public async Task AsyncMap_14_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+            record[11].Returns(12);
+            record[12].Returns(13);
+            record[13].Returns(14);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11,
+                int value12, int value13, int value14) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11,
+                value12,
+                value13,
+                value14
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+            Assert.AreEqual(12, result.First()[11]);
+            Assert.AreEqual(13, result.First()[12]);
+            Assert.AreEqual(14, result.First()[13]);
+        }
+
+        [Test]
+        public async Task AsyncMap_15_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+            record[11].Returns(12);
+            record[12].Returns(13);
+            record[13].Returns(14);
+            record[14].Returns(15);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11,
+                int value12, int value13, int value14, int value15) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11,
+                value12,
+                value13,
+                value14,
+                value15
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+            Assert.AreEqual(12, result.First()[11]);
+            Assert.AreEqual(13, result.First()[12]);
+            Assert.AreEqual(14, result.First()[13]);
+            Assert.AreEqual(15, result.First()[14]);
+        }
+
+        [Test]
+        public async Task AsyncMap_16_Should_Return_Result()
+        {
+            var record = Substitute.For<IRecord>();
+            record[0].Returns(1);
+            record[1].Returns(2);
+            record[2].Returns(3);
+            record[3].Returns(4);
+            record[4].Returns(5);
+            record[5].Returns(6);
+            record[6].Returns(7);
+            record[7].Returns(8);
+            record[8].Returns(9);
+            record[9].Returns(10);
+            record[10].Returns(11);
+            record[11].Returns(12);
+            record[12].Returns(13);
+            record[13].Returns(14);
+            record[14].Returns(15);
+            record[15].Returns(16);
+
+            var cursor = Substitute.For<IStatementResultCursor>();
+            cursor.FetchAsync().Returns(Task.FromResult(true), Task.FromResult(true), Task.FromResult(false));
+            cursor.Current.Returns(record, record);
+
+            var result = await cursor.AsyncMap((int value1, int value2, int value3, int value4, int value5,
+                int value6, int value7, int value8, int value9, int value10, int value11,
+                int value12, int value13, int value14, int value15, int value16) => new[]
+            {
+                value1,
+                value2,
+                value3,
+                value4,
+                value5,
+                value6,
+                value7,
+                value8,
+                value9,
+                value10,
+                value11,
+                value12,
+                value13,
+                value14,
+                value15,
+                value16
+            }).ToListAsync().ConfigureAwait(false);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual(1, result.First()[0]);
+            Assert.AreEqual(2, result.First()[1]);
+            Assert.AreEqual(3, result.First()[2]);
+            Assert.AreEqual(4, result.First()[3]);
+            Assert.AreEqual(5, result.First()[4]);
+            Assert.AreEqual(6, result.First()[5]);
+            Assert.AreEqual(7, result.First()[6]);
+            Assert.AreEqual(8, result.First()[7]);
+            Assert.AreEqual(9, result.First()[8]);
+            Assert.AreEqual(10, result.First()[9]);
+            Assert.AreEqual(11, result.First()[10]);
+            Assert.AreEqual(12, result.First()[11]);
+            Assert.AreEqual(13, result.First()[12]);
+            Assert.AreEqual(14, result.First()[13]);
+            Assert.AreEqual(15, result.First()[14]);
+            Assert.AreEqual(16, result.First()[15]);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>UnitTests</AssemblyName>
     <RootNamespace>UnitTests</RootNamespace>
   </PropertyGroup>
@@ -11,10 +11,11 @@
     <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Neo4jMapper\Neo4jMapper.csproj" />
+    <ProjectReference Include="..\Neo4jMapperCore\Neo4jMapperCore.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I like the work you’d done with the Neo4J mapping library 
so instead of building my own parallel version I would like to contribute your code base.

As a technical guy it was easier for me to offer my idea via pull request rather trying to explain it verbosely as an issue.

The idea was to support modern C# 8 Async Stream (IAsyncEnumerable).
The benefit of it are potentially fetching less data (and result in less object mapping) 
in scenarios like: 
foreach (var p in await cursor.MapAsync<Person>()).TakeWhile(p => p.born < 1970))
This kind of query will execute the TakeWhile(p => p.born < 1970)
after fetching and mapping all of the object when it might need a small friction of it.

The alternative is:
await foreach (var p in cursor.AsyncMap<Person>().TakeWhile(p => p.born < 1970))
Which will stop fetching as soon as the TakeWhile tern return false.

In order to achieve it I did the following modification to your existing code base:
- Adding .NET Core 3 Library (Neo4jMapperCore) which mirror your code base (Neo4jMapper) using linked file (I didn't change the existing project for keeping backward compatibility with older .NET version).
Add single file to this library, for the AsyncMap implementation (StatementResultCursorCoreExtensions).
- Test projects 
  - Convert to .NET Core 3.
  - Change the reference to  Neo4jMapperCore.
  - Add NuGet reference to System.Linq.Async in order to test LINQ query over IAsyncEnumerable
- Integration Test
  - I was adding support for getting the database credentials via Environment Variable,
    while keeping the your setting as default.

I hope you find it useful and decide to add it to your code base.
I would be happy to contribute more in the future.

Bnaya Eshet
CTO of Weknow Network
