### PR TITLE
solve the enum serialization issue without mapping to entity

### DIFF
--- a/src/IntegrationTests/TestFixtureBase.cs
+++ b/src/IntegrationTests/TestFixtureBase.cs
@@ -10,7 +10,7 @@ namespace IntegrationTests
         [OneTimeSetUp]
         protected virtual void TestFixtureSetUp()
         {
-            Driver = GraphDatabase.Driver("bolt://localhost:7687");
+            Driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.Basic("neo4j", "123456"));
 
             // Ensure node exists to avoid flaky test where node id = 0
             using (var session = Driver.Session())

--- a/src/IntegrationTests/Tests/BasicTests.cs
+++ b/src/IntegrationTests/Tests/BasicTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using IntegrationTests.Models;

--- a/src/IntegrationTests/Tests/EnumHandlingTests.cs
+++ b/src/IntegrationTests/Tests/EnumHandlingTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using IntegrationTests.Models;
+using Neo4jMapper;
+using NUnit.Framework;
+
+namespace IntegrationTests.Tests
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class EnumHandlingTests : MoviesFixtureBase
+    {
+        [Test]
+        public async Task Should_Map_Enum()
+        {
+            await Session.RunAsync(@"
+                MATCH (n:Payload {Id: 1})
+                Detach Delete n").ConfigureAwait(false);
+
+            var payload = new Payload
+            {
+                Id = 1,
+                Color = ConsoleColor.Red,
+                Name = "Test 1"
+            };
+
+            var parms = new Neo4jParameters()
+             .WithEntity<Payload>("map", payload,
+                        (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
+
+            var cursor = await Session.RunAsync(@"
+                CREATE (n:Payload $map)
+                RETURN n", parms).ConfigureAwait(false);
+
+            var result = await cursor
+                .MapSingleAsync<Payload>().ConfigureAwait(false);
+
+            Assert.AreEqual(payload, result);
+        }
+        [Test]
+        public async Task Should_Map_Entities_Enum()
+        {
+            await Session.RunAsync(@"
+                MATCH (n:Payload {Id: 1})
+                Detach Delete n").ConfigureAwait(false);
+            await Session.RunAsync(@"
+                MATCH (n:Payload {Id: 2})
+                Detach Delete n").ConfigureAwait(false);
+
+            var payloads = new[]
+            {
+                new Payload
+                {
+                    Id = 1,
+                    Color = ConsoleColor.Red,
+                    Name = "Test 1"
+                },
+                new Payload
+                {
+                    Id = 2,
+                    Color = ConsoleColor.Green,
+                    Name = "Test 2"
+                },
+            };
+
+            var parms = new Neo4jParameters()
+             .WithEntities<Payload>("map", payloads,
+                        (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
+
+            var cursor = await Session.RunAsync(@"
+                CREATE (n:Payload $map)
+                RETURN n", parms).ConfigureAwait(false);
+
+            var result = await cursor
+                .MapAsync<Payload>().ConfigureAwait(false);
+
+            Assert.AreEqual(payloads, result);
+        }
+        class Payload : IEquatable<Payload>
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public ConsoleColor Color { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Payload);
+            }
+
+            public bool Equals([AllowNull] Payload other)
+            {
+                return other != null &&
+                       Id == other.Id &&
+                       Name == other.Name &&
+                       Color == other.Color;
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Id, Name, Color);
+            }
+
+            public static bool operator ==(Payload left, Payload right)
+            {
+                return EqualityComparer<Payload>.Default.Equals(left, right);
+            }
+
+            public static bool operator !=(Payload left, Payload right)
+            {
+                return !(left == right);
+            }
+        }
+    }
+}

--- a/src/IntegrationTests/Tests/EnumHandlingTests.cs
+++ b/src/IntegrationTests/Tests/EnumHandlingTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
-using IntegrationTests.Models;
+using Neo4j.Driver.V1;
 using Neo4jMapper;
 using NUnit.Framework;
 
@@ -11,47 +10,52 @@ namespace IntegrationTests.Tests
 {
     [TestFixture]
     [NonParallelizable]
-    public class EnumHandlingTests : MoviesFixtureBase
+    public class EnumHandlingTests : TestFixtureBase
     {
         [Test]
         public async Task Should_Map_Enum()
         {
-            await Session.RunAsync(@"
+            using (var session = Driver.Session(AccessMode.Write))
+            {
+                await session.RunAsync(@"
                 MATCH (n:Payload {Id: 1})
                 Detach Delete n").ConfigureAwait(false);
 
-            var payload = new Payload
-            {
-                Id = 1,
-                Color = ConsoleColor.Red,
-                Name = "Test 1"
-            };
+                var payload = new Payload
+                {
+                    Id = 1,
+                    Color = ConsoleColor.Red,
+                    Name = "Test 1"
+                };
 
-            var parms = new Neo4jParameters()
-             .WithEntity<Payload>("map", payload,
-                        (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
+                var parms = new Neo4jParameters()
+                 .WithEntity<Payload>("map", payload,
+                            (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
 
-            var cursor = await Session.RunAsync(@"
+                var cursor = await session.RunAsync(@"
                 CREATE (n:Payload $map)
                 RETURN n", parms).ConfigureAwait(false);
 
-            var result = await cursor
-                .MapSingleAsync<Payload>().ConfigureAwait(false);
+                var result = await cursor
+                    .MapSingleAsync<Payload>().ConfigureAwait(false);
 
-            Assert.AreEqual(payload, result);
+                Assert.AreEqual(payload, result);
+            }
         }
         [Test]
         public async Task Should_Map_Entities_Enum()
         {
-            await Session.RunAsync(@"
+            using (var session = Driver.Session(AccessMode.Write))
+            {
+                await session.RunAsync(@"
                 MATCH (n:Payload {Id: 1})
                 Detach Delete n").ConfigureAwait(false);
-            await Session.RunAsync(@"
+                await session.RunAsync(@"
                 MATCH (n:Payload {Id: 2})
                 Detach Delete n").ConfigureAwait(false);
 
-            var payloads = new[]
-            {
+                var payloads = new[]
+                {
                 new Payload
                 {
                     Id = 1,
@@ -66,18 +70,21 @@ namespace IntegrationTests.Tests
                 },
             };
 
-            var parms = new Neo4jParameters()
-             .WithEntities<Payload>("map", payloads,
-                        (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
+                var parms = new Neo4jParameters()
+                 .WithEntities<Payload>("items", payloads,
+                            (k, v) => k == nameof(Payload.Color) ? v.ToString() : v);
 
-            var cursor = await Session.RunAsync(@"
-                CREATE (n:Payload $map)
+                var cursor = await session.RunAsync(@"
+                UNWIND $items AS item
+                CREATE (n:Payload)
+                SET n = item 
                 RETURN n", parms).ConfigureAwait(false);
 
-            var result = await cursor
-                .MapAsync<Payload>().ConfigureAwait(false);
+                var result = await cursor
+                    .MapAsync<Payload>().ConfigureAwait(false);
 
-            Assert.AreEqual(payloads, result);
+                Assert.AreEqual(payloads, result);
+            }
         }
         class Payload : IEquatable<Payload>
         {

--- a/src/Neo4jMapper/DictionaryExtensions.cs
+++ b/src/Neo4jMapper/DictionaryExtensions.cs
@@ -1,20 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Neo4jMapper
 {
     public static class DictionaryExtensions
     {
-        public static IDictionary<string, object> WithEntity<T>(this IDictionary<string, object> dictionary, string key, T entity) where  T : class
+        public static IDictionary<string, object> WithEntity<T>(
+            this IDictionary<string, object> dictionary,
+            string key,
+            T entity,
+            Func<string, object, object> mapper = null) where  T : class
         {
-            dictionary.WithMap(entity.ToParameterMap(key));
+            dictionary.WithMap(entity.ToParameterMap(key, mapper));
 
             return dictionary;
         }
 
-        public static IDictionary<string, object> WithEntities<T>(this IDictionary<string, object> dictionary, string key, IEnumerable<T> entities) where  T : class
+        public static IDictionary<string, object> WithEntities<T>(
+            this IDictionary<string, object> dictionary,
+            string key,
+            IEnumerable<T> entities,
+            Func<string, object, object> mapper = null) where  T : class
         {
-            dictionary.WithMaps(entities.ToParameterMaps(key));
+            dictionary.WithMaps(entities.ToParameterMaps(key, mapper));
 
             return dictionary;
         }

--- a/src/Neo4jMapper/EntityExtensions.cs
+++ b/src/Neo4jMapper/EntityExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using ServiceStack;
 
@@ -6,15 +7,29 @@ namespace Neo4jMapper
 {
     public static class EntityExtensions
     {
-        public static KeyValuePair<string, IReadOnlyDictionary<string, object>> ToParameterMap<T>(this T entity, string key) where T : class
+        public static KeyValuePair<string, IReadOnlyDictionary<string, object>> ToParameterMap<T>(
+            this T entity,
+            string key,
+            Func<string, object, object> mapper = null) where T : class
         {
             var map = entity.ToObjectDictionary();
+            if(mapper != null)
+                map= map.ToDictionary(p => p.Key, p => mapper(p.Key, p.Value));
             return new KeyValuePair<string, IReadOnlyDictionary<string, object>>(key, map);
         }
 
-        public static KeyValuePair<string, IEnumerable<IReadOnlyDictionary<string, object>>> ToParameterMaps<T>(this IEnumerable<T> entities, string key) where T : class
+        public static KeyValuePair<string, IEnumerable<IReadOnlyDictionary<string, object>>> ToParameterMaps<T>(
+            this IEnumerable<T> entities,
+            string key,
+            Func<string, object, object> mapper = null) where T : class
         {
-            var map = entities.Select(p => p.ToObjectDictionary());
+            var map = entities.Select(p =>
+            {
+                var map = p.ToObjectDictionary();
+                if (mapper != null)
+                    map = map.ToDictionary(p => p.Key, p => mapper(p.Key, p.Value));
+                return map;
+            });
             return new KeyValuePair<string, IEnumerable<IReadOnlyDictionary<string, object>>>(key, map);
         }
     }


### PR DESCRIPTION
I suggest this solution to the enum serialization problem.
https://github.com/barnardos-au/Neo4jMapper/issues/17
This solution solve the problem with very little footprint.
And It can be improve it's own performance after tiny contribution to ServiceStack (https://github.com/ServiceStack/ServiceStack/pull/1215).
ServiceStack conribution will add the mapper to ToObjectDictionary which will avoid the second iteration on the dictionary.